### PR TITLE
Remove the ability to restoring from database

### DIFF
--- a/lib/restoreThemeLiquid.js
+++ b/lib/restoreThemeLiquid.js
@@ -1,16 +1,4 @@
-module.exports = async (html, redisStore, shop) => {
-	let shopDb = {};
-	try {
-		shopDb = JSON.parse(await redisStore.getAsync(shop));
-	} catch (e) {
-		console.log(e);
-	}
-
-	// If a backup of the theme.liquid html was found, restore from there
-	if(shopDb.originalTheme) {
-		console.log("returning from original theme from redis", shopDb.originalTheme);
-		return shopDb.originalTheme
-	}
+module.exports = async (html) => {
 
 	// Otherwise remvove critical css from theme.liquid
 	


### PR DESCRIPTION
Initially I thought that creating a copy of theme.liquid on initial install and restoring from here is a good idea. Until one client tried to do this and realised he'd lost changes he's made to the theme.liquid in the process. Doh! Reverting this...

